### PR TITLE
First pass on hooks.

### DIFF
--- a/lib/interactor.ex
+++ b/lib/interactor.ex
@@ -1,6 +1,9 @@
 defmodule Interactor do
   use Behaviour
-  @callback call(map) :: Interactor.Results.t | Task.t
+  @callback call(map) :: any
+  @callback before_call(map) :: map
+  @callback after_call(any) :: any
+  @callback after_perform(any) :: any
 
   defmacro __using__(opts) do
     quote do
@@ -27,13 +30,15 @@ defmodule Interactor do
 
   defp define_peform do
     quote do
-      @spec perform(map) :: Interactor.Results.t
-       def perform(map) do
-         %Interactor.Results{
-           results: Interactor.Handler.handle(call(map), @_repo),
-           context: map
-         }
-       end
+      def perform(input) do
+        Interactor.Perform.perform(__MODULE__, input, @_repo)
+      end
+
+      def before_call(c), do: c
+      def after_call(r), do: r
+      def after_perform(r), do: r
+
+      defoverridable [before_call: 1, after_call: 1, after_perform: 1]
     end
   end
 
@@ -41,36 +46,6 @@ defmodule Interactor do
     quote do
       @spec perform_async(map) :: Task.t
       def perform_async(map), do: Task.async(__MODULE__, :perform, [map])
-    end
-  end
-
-  defmodule Results do
-    defstruct [:results, :context]
-    @type t :: %__MODULE__{}
-  end
-
-  # Handle call responses
-
-  defprotocol Handler do
-    @fallback_to_any true
-    def handle(data, repo)
-  end
-
-  defimpl Handler, for: Any do
-    def handle(data, _repo), do: data
-  end
-
-  if Code.ensure_compiled?(Ecto.Multi) do
-    defimpl Handler, for: Ecto.Multi do
-      def handle(_multi, nil), do: raise "No repo defined."
-      def handle(multi, repo), do: repo.transaction(multi)
-    end
-  end
-
-  if Code.ensure_compiled?(Ecto.Changeset) do
-    defimpl Handler, for: Ecto.Changeset do
-      def handle(changeset, nil), do: raise "No repo defined."
-      def handle(changeset, repo), do: repo.insert_or_update(changeset)
     end
   end
 end

--- a/lib/interactor/handler.ex
+++ b/lib/interactor/handler.ex
@@ -1,0 +1,22 @@
+defprotocol Interactor.Handler do
+  @fallback_to_any true
+  def handle(data, repo)
+end
+
+defimpl Interactor.Handler, for: Any do
+  def handle(data, _repo), do: data
+end
+
+if Code.ensure_compiled?(Ecto.Multi) do
+  defimpl Interactor.Handler, for: Ecto.Multi do
+    def handle(_multi, nil), do: raise "No repo defined."
+    def handle(multi, repo), do: repo.transaction(multi)
+  end
+end
+
+if Code.ensure_compiled?(Ecto.Changeset) do
+  defimpl Interactor.Handler, for: Ecto.Changeset do
+    def handle(changeset, nil), do: raise "No repo defined."
+    def handle(changeset, repo), do: repo.insert_or_update(changeset)
+  end
+end

--- a/lib/interactor/perform.ex
+++ b/lib/interactor/perform.ex
@@ -1,0 +1,20 @@
+defmodule Interactor.Perform do
+  def perform(interactor, input, nil) do
+    do_perform(interactor, input, nil)
+  end
+
+  def perform(interactor, input, repo) do
+    repo.transaction fn ->
+      do_perform(interactor, input, repo)
+    end
+  end
+
+  defp do_perform(interactor, input, repo) do
+    input
+    |> interactor.before_call
+    |> interactor.call
+    |> interactor.after_call
+    |> Interactor.Handler.handle(repo)
+    |> interactor.after_perform
+  end
+end

--- a/lib/interactor/perform.ex
+++ b/lib/interactor/perform.ex
@@ -1,15 +1,5 @@
 defmodule Interactor.Perform do
-  def perform(interactor, input, nil) do
-    do_perform(interactor, input, nil)
-  end
-
   def perform(interactor, input, repo) do
-    repo.transaction fn ->
-      do_perform(interactor, input, repo)
-    end
-  end
-
-  defp do_perform(interactor, input, repo) do
     input
     |> interactor.before_call
     |> interactor.call

--- a/test/interactor_test.exs
+++ b/test/interactor_test.exs
@@ -16,7 +16,8 @@ defmodule InteractorTest do
       %Foo{foo: Ecto.Changeset.get_field(changeset, :foo)}
     end
 
-    def transaction(multi) do
+    def transaction(fun) when is_function(fun), do: fun.()
+    def transaction(%Ecto.Multi{} = multi) do
       foos = multi
               |> Ecto.Multi.to_list
               |> Enum.reduce(%{}, fn({key, {_, cs, _}}, m) ->
@@ -46,35 +47,35 @@ defmodule InteractorTest do
   end
 
   test "simple - calling perform" do
-    assert {:ok, "foobar"} = SimpleExample.perform(%{foo: "bar"}).results
+    assert {:ok, "foobar"} = SimpleExample.perform(%{foo: "bar"})
   end
 
   test "simple - calling perform async" do
     task = SimpleExample.perform_async(%{foo: "bar"})
-    assert {:ok, "foobar"} = Task.await(task).results
+    assert {:ok, "foobar"} = Task.await(task)
   end
 
   test "changeset - calling perform" do
-    foo = ChangesetExample.perform(%{foo: "bar"}).results
+    foo = ChangesetExample.perform(%{foo: "bar"})
     assert foo.foo == "bar"
   end
 
   test "changeset - calling perform async" do
     task = ChangesetExample.perform_async(%{foo: "bar"})
-    foo = Task.await(task).results
+    foo = Task.await(task)
     assert foo.foo == "bar"
   end
 
   test "multi - calling perform" do
     results = MultiExample.perform(%{foo1: "bar", foo2: "baz"})
-    assert {:ok, %{foo1: foo1, foo2: foo2}} = results.results
+    assert {:ok, %{foo1: foo1, foo2: foo2}} = results
     assert foo1.foo == "bar"
     assert foo2.foo == "baz"
   end
 
   test "multi - calling perform async" do
     task = MultiExample.perform_async(%{foo1: "bar", foo2: "baz"})
-    assert {:ok, %{foo1: foo1, foo2: foo2}} = Task.await(task).results
+    assert {:ok, %{foo1: foo1, foo2: foo2}} = Task.await(task)
     assert foo1.foo == "bar"
     assert foo2.foo == "baz"
   end


### PR DESCRIPTION
Adds three callbacks and a transaction to perform lifecycle.
- `before_call/1` is called first and what ever it returns is passed to call.
- `call/1` is called next.
- `after_call/1` is called next, but before anything is implicitly executed.
- `Interactor.Handler.handle/2` protocol is called next, this is where changesets and multis are actually executed, and can be extended.
- `after_perform/1` is called last, after the multi or changeset is inserted. It can be used to format results or to fire off jobs or even call other interactors.

All above hooks are wrapped in a transaction.

@beerlington @totallymike Any feedback/thoughts on hooks? 
