### PR TITLE
Remove `call/1` and friends from using modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,31 @@
 This is a library implementing a simple pattern that encourages modularity and
 the Single Responsibility Principle around _doing_ things primarially with ecto.
 
-The goal is a module whose sole responsibility is doing one thing, removing that
-responsibility from the schema (model) module. Some examples might be:
+You can think of this as a second layer of domain modeling that happens in your
+application. You existing schema (model) layer represents the data itself and
+it's relationships. The new interaction layer represents high level actions or
+events that happen on your domain. Some good examples in a blog domain might be:
 
-* CreatePost
-* UpdatePost
-* DeletePost
+* CreateArticle
+* UpdateArticle
+* DeleteArticle
+* TrackArticleView
 * RegisterUser
-* TrackPostView
+* SpamifyUser
+* ResetUserPassword
 * CreateComment
+* DeleteComment
 
-The goal is simple schemas that don't change much over time, and easy to
-maintain, test, and understand modules in charge of creating things.
+By seperating these actions into their own modules you gain smaller "models"
+and controllers. The interactors themselves stay extremely focused and the code
+easy to maintain.
 
-In addition each module has three ways the same logic can be called:
-
-* call - returns the Changeset or Multi (or other) to be handled by caller.
-* perform - executes the Changeset or Multi
-* perform_async - executes the Changeset or Multi in the returned Task
-
-It is inspired by CollectiveIdea's Ruby gem Interactors and influenced by
-Ello's async interactors and years of working on many MVC apps.
+Interactor is inspired by CollectiveIdea's Ruby gem Interactors and influenced
+by Ello's async interactor usage and years of working on many MVC apps.
 
 ## What this isn't
 
-**Fully baked.**
+*Fully baked.*
 
 This is an experiment in application architectual patterns using the tools
 Elixir and Ecto provide. Ecto Changesets and Multi are (relatively) new
@@ -38,11 +38,11 @@ concepts (to me) and these theories need testing out.
 
 Is this a good idea? A bad one? Open an issue and let me know!
 
-**A lot of code**
+*A lot of code*
 
 This library really doesn't do much, but it doesn't need to. This is mostly
 about promoting and enabling a pattern to make Elixir/Phoenix apps even more
-maintainable.
+maintainable then they already are.
 
 ## Installation
 
@@ -62,31 +62,31 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
 ## Examples
 
-### A basic 'post creation' interactor
+### A basic 'Article creation' interactor
 
 ```elixir
-defmodule ExampleApp.CreatePost do
-  alias ExampleApp.Post
+defmodule ExampleApp.CreateArticle do
   use Interactor, repo: ExampleApp.Repo
+  alias ExampleApp.Article
 
-  def call(%{post: params, author: author}) do
-    cast(%Post{}, params, [:title, :body])
+  def handle_call(%{attributes: attrs, author: author}) do
+    cast(%Article{}, attrs, [:title, :body])
     |> put_change(:author_id, author.id)
     # validations etc
   end
 end
 
-defmodule ExampleApp.PostController do
+defmodule ExampleApp.ArticleController do
   use ExampleApp.Web, :controller
-  alias ExampleApp.CreatePost
+  alias ExampleApp.CreateArticle
 
-  def post(%{assigns: %{user: user}} = conn, %{post: params}) do
-    case CreatePost.perform(%{post: params, author: user}).results do
-      {:ok, post} ->
+  def post(%{assigns: %{user: user}} = conn, %{article: attrs}) do
+    case Interactor.call(CreateArticle, %{attributes: attrs, author: user}) do
+      {:ok, article} ->
         conn
         |> put_status(:created)
-        |> put_resp_header("location", post_path(conn, :show, post))
-        |> render(:show, post: post)
+        |> put_resp_header("location", article_path(conn, :show, article))
+        |> render(:show, article: article)
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -101,18 +101,18 @@ end
 A more complicated example might involve updating the author as well:
 
 ```elixir
-defmodule ExampleApp.CreatePost do
-  alias ExampleApp.Post
+defmodule ExampleApp.CreateArticle do
   use Interactor, repo: ExampleApp.Repo
+  alias ExampleApp.Article
 
-  def call(%{post: params, author: author}) do
+  def handle_call(%{attributes: attrs, author: author}) do
     Multi.new
-    |> Multi.insert(:post, post_changeset(params, author))
+    |> Multi.insert(:article, article_changeset(attrs, author))
     |> Multi.update(:author, author_changset(author))
   end
 
-  defp post_changeset(params, author)
-    cast(%Post{}, params, [:title, :body])
+  defp post_changeset(attrs, author)
+    cast(%Article{}, attrs, [:title, :body])
     |> put_change(:author_id, author.id)
     # validations etc
   end
@@ -122,16 +122,16 @@ defmodule ExampleApp.CreatePost do
   end
 end
 
-defmodule ExampleApp.PostController do
+defmodule ExampleApp.ArticleController do
   use ExampleApp.Web, :controller
-  alias ExampleApp.CreatePost
+  alias ExampleApp.CreateArticle
 
-  def post(%{assigns: %{user: user}} = conn, %{post: params}) do
-    case CreatePost.perform(%{post: params, author: user}).results do
-      {:ok, %{post: post}} ->
+  def post(%{assigns: %{user: user}} = conn, %{article: attrs}) do
+    case Interactor.call(CreateArticle, %{attributes: attrs, author: user}) do
+      {:ok, %{article: article}} ->
         conn
         |> put_status(:created)
-        |> put_resp_header("location", post_path(conn, :show, post))
+        |> put_resp_header("location", article_path(conn, :show, article))
         |> render(:show, post: post)
       {:error, _, changeset, _} ->
         conn
@@ -142,11 +142,9 @@ defmodule ExampleApp.PostController do
 end
 ```
 
-
 ## TODO:
 
-* Callbacks? - A per interactor way of formatting the ecto response might be nice
-* Use it in some more real projects
+* Chainability?
 * Collect feedback
 * Release to hex.pm
 

--- a/lib/interactor.ex
+++ b/lib/interactor.ex
@@ -1,18 +1,107 @@
 defmodule Interactor do
   use Behaviour
+  alias Interactor.TaskSupervisor
+
+  @moduledoc """
+  A tool for modeling events that happen in your application.
+
+  TODO: More on interactor concept
+
+  Interactor provided a behaviour and functions to execute the behaviours.
+
+  To use simply `use Interactor` in a module and implement the `handle_call/1`
+  callback. When `use`-ing you can optionaly include a Repo option which will
+  be used to execute any Ecto.Changesets or Ecto.Multi structs you return.
+
+  Interactors supports three callbacks:
+
+    * `before_call/1` - Useful for manipulating input etc.
+    * `handle_call/1` - The meat, usually returns an Ecto.Changeset or Ecto.Multi.
+    * `after_call/1` - Useful for metrics, publishing events, etc
+
+  Interactors can be called in three ways:
+
+    * `Interactor.call/2` - Executes callbacks, optionaly insert, and return results.
+    * `Interactor.call_task/2` - Same as call, but returns a `Task` that can be awated on.
+    * `Interactor.call_aysnc/2` - Same as call, but does not return results.
+
+  Example:
+
+      defmodule CreateArticle do
+        use Interactor, repo: Repo
+
+        def handle_call(%{attributes: attrs, author: author}) do
+          cast(%Article{}, attrs, [:title, :body])
+          |> put_change(:author_id, author.id)
+        end
+      end
+
+      Interactor.call(CreateArticle, %{attributes: params, author: current_user})
+  """
+
+  @doc """
+  The primary callback. Typically returns an Ecto.Changeset or an Ecto.Multi.
+  """
   @callback handle_call(map) :: any
+
+  @doc """
+  A callback executed before handle_call. Useful for normalizing inputs.
+  """
   @callback before_call(map) :: map
+
+  @doc """
+  A callback executed after handle_call and after the Repo executes.
+
+  Useful for publishing events, tracking metrics, and other non-transaction
+  worthy calls.
+  """
   @callback after_call(any) :: any
+
+  @doc """
+  Executes the `before_call/1`, `handle_call/1`, and `after_call/1` callbacks.
+
+  If an Ecto.Changeset or Ecto.Multi is returned by `handle_call/1` and a
+  `repo` options was passed to `use Interactor` the changeset or multi will be
+  executed and the results returned.
+  """
+  @spec call_task(module, map) :: Task.t
+  def call(interactor, context) do
+    context
+    |> interactor.before_call
+    |> interactor.handle_call
+    |> Interactor.Handler.handle(interactor.__repo)
+    |> interactor.after_call
+  end
+
+  @doc """
+  Wraps `call/2` in a supervised Task. Returns the Task.
+
+  Useful if you want async, but want to await results.
+  """
+  @spec call_task(module, map) :: Task.t
+  def call_task(interactor, map) do
+    Task.Supervisor.async(TaskSupervisor, Interactor, :call, [interactor, map])
+  end
+
+  @doc """
+  Executes `call/2` asynchronously via a supervised task. Returns {:ok, pid}.
+
+  Primary use case is task you want completely asynchronos with no care for
+  return values.
+  """
+  @spec call_async(module, map) :: {:ok, pid}
+  def call_async(interactor, map) do
+    Task.Supervisor.start_child(TaskSupervisor, Interactor, :call, [interactor, map])
+  end
 
   defmacro __using__(opts) do
     quote do
-      @_repo Keyword.get(unquote(opts), :repo)
       @behaviour Interactor
+      @doc false
+      def __repo, do: unquote(opts[:repo])
       unquote(import_changeset)
       unquote(alias_multi)
-      unquote(define_call)
-      unquote(define_call_task)
-      unquote(define_call_async)
+      unquote(define_callback_defaults)
     end
   end
 
@@ -28,40 +117,12 @@ defmodule Interactor do
     defp alias_multi, do: nil
   end
 
-  defp define_call do
+  defp define_callback_defaults do
     quote do
-      def call(input) do
-        Interactor.call(__MODULE__, input, @_repo)
-      end
-
       def before_call(c), do: c
       def after_call(r), do: r
 
       defoverridable [before_call: 1, after_call: 1]
     end
-  end
-
-  defp define_call_task do
-    quote do
-      @spec call_task(map) :: Task.t
-      def call_task(map),
-        do: Task.Supervisor.async(Interactor.TaskSupervisor, __MODULE__, :call, [map])
-    end
-  end
-
-  defp define_call_async do
-    quote do
-      @spec call_aync(map) :: {:ok, pid}
-      def call_aync(map),
-        do: Task.Supervisor.start_child(Interactor.TaskSupervisor, __MODULE__, :call, [map])
-    end
-  end
-
-  def call(interactor, input, repo) do
-    input
-    |> interactor.before_call
-    |> interactor.handle_call
-    |> Interactor.Handler.handle(repo)
-    |> interactor.after_call
   end
 end

--- a/lib/interactor/handler.ex
+++ b/lib/interactor/handler.ex
@@ -9,14 +9,14 @@ end
 
 if Code.ensure_compiled?(Ecto.Multi) do
   defimpl Interactor.Handler, for: Ecto.Multi do
-    def handle(_multi, nil), do: raise "No repo defined."
+    def handle(multi, nil),  do: multi
     def handle(multi, repo), do: repo.transaction(multi)
   end
 end
 
 if Code.ensure_compiled?(Ecto.Changeset) do
   defimpl Interactor.Handler, for: Ecto.Changeset do
-    def handle(changeset, nil), do: raise "No repo defined."
+    def handle(changeset, nil),  do: changeset
     def handle(changeset, repo), do: repo.insert_or_update(changeset)
   end
 end

--- a/test/interactor_test.exs
+++ b/test/interactor_test.exs
@@ -41,40 +41,38 @@ defmodule InteractorTest do
     use Interactor, repo: FakeRepo
     def handle_call(%{foo1: foo1, foo2: foo2}) do
       Multi.new
-      |> Multi.insert(:foo1, ChangesetExample.call(%{foo: foo1}))
-      |> Multi.insert(:foo2, ChangesetExample.call(%{foo: foo2}))
+      |> Multi.insert(:foo1, ChangesetExample.handle_call(%{foo: foo1}))
+      |> Multi.insert(:foo2, ChangesetExample.handle_call(%{foo: foo2}))
     end
   end
 
   test "simple - calling call" do
-    assert {:ok, "foobar"} = SimpleExample.call(%{foo: "bar"})
+    assert {:ok, "foobar"} = Interactor.call(SimpleExample, %{foo: "bar"})
   end
 
   test "simple - calling call_task" do
-    task = SimpleExample.call_task(%{foo: "bar"})
+    task = Interactor.call_task(SimpleExample, %{foo: "bar"})
     assert {:ok, "foobar"} = Task.await(task)
   end
 
-  test "changeset - calling perform" do
-    foo = ChangesetExample.call(%{foo: "bar"})
+  test "changeset - calling call" do
+    foo = Interactor.call(ChangesetExample, %{foo: "bar"})
     assert foo.foo == "bar"
   end
 
   test "changeset - calling call_task" do
-    task = ChangesetExample.call_task(%{foo: "bar"})
+    task = Interactor.call_task(ChangesetExample, %{foo: "bar"})
     foo = Task.await(task)
     assert foo.foo == "bar"
   end
 
-  test "multi - calling perform" do
-    results = MultiExample.call(%{foo1: "bar", foo2: "baz"})
-    assert {:ok, %{foo1: foo1, foo2: foo2}} = results
-    assert foo1.foo == "bar"
-    assert foo2.foo == "baz"
+  test "multi - calling call_async" do
+    results = Interactor.call_async(MultiExample, %{foo1: "bar", foo2: "baz"})
+    assert {:ok, _} = results
   end
 
   test "multi - calling call_task" do
-    task = MultiExample.call_task(%{foo1: "bar", foo2: "baz"})
+    task = Interactor.call_task(MultiExample, %{foo1: "bar", foo2: "baz"})
     assert {:ok, %{foo1: foo1, foo2: foo2}} = Task.await(task)
     assert foo1.foo == "bar"
     assert foo2.foo == "baz"


### PR DESCRIPTION
Defining functions that are not default callback implementation is
discouraged in Elixir. This replaces that with a much more conventional
approach.

Example:

``` elixir
# Before (bad)
CreateArticle.call(%{attributes: attrs})

# Now (good)
Interactor.call(CreateArticle, %{attributes: attrs})
```
