### PR TITLE
[WIP] - Organizers

### DIFF
--- a/lib/interactor.ex
+++ b/lib/interactor.ex
@@ -128,7 +128,7 @@ defmodule Interactor do
     quote do
       def before_call(c), do: c
       def after_call(r), do: r
-      def cleanup(x), do: x
+      def cleanup(x), do: {:ok, x}
 
       defoverridable [before_call: 1, after_call: 1, cleanup: 1]
     end

--- a/lib/interactor/organizer.ex
+++ b/lib/interactor/organizer.ex
@@ -1,0 +1,43 @@
+defmodule Interactor.Organizer do
+  defmacro __using__(opts) do
+    quote do
+      use Interactor, unquote(opts)
+      import Interactor.Organizer, only: [organize: 1]
+
+      Module.register_attribute(__MODULE__, :interactors, accumulate: true)
+    end
+  end
+
+  defmacro organize(interactors) do
+    quote do
+      import Interactor.Organizer
+      unquote(interactors)
+      |> Enum.reverse
+      |> Enum.each(&(Module.put_attribute(__MODULE__, :interactors, &1)))
+      unquote(define_callbacks)
+    end
+  end
+
+  defp define_callbacks do
+    quote do
+      def handle_call(attributes) do
+        execute_interactors(attributes, @interactors)
+      end
+    end
+  end
+
+  def execute_interactors(context, []), do: {:ok, context}
+  def execute_interactors(context, [interactor | interactors]) do
+    try do
+      with {:ok, new_context} <- Interactor.call(interactor, context) do
+        case execute_interactors(new_context, interactors) do
+          {:error, error} ->
+            {:ok, _} = interactor.cleanup(new_context)
+            {:error, error, new_context}
+          other -> other
+        end
+      end
+    rescue error -> {:error, error}
+    end
+  end
+end

--- a/lib/interactor/organizer.ex
+++ b/lib/interactor/organizer.ex
@@ -37,7 +37,7 @@ defmodule Interactor.Organizer do
             handle_cleanup(interactor, error, new_context)
           other -> other
         end
-      rescue error in RuntimeError -> handle_cleanup(interactor, error, new_context)
+      rescue error -> handle_cleanup(interactor, error, new_context)
       end
     end
   end

--- a/test/organizer_test.exs
+++ b/test/organizer_test.exs
@@ -1,0 +1,59 @@
+defmodule OrganizerTest do
+  use ExUnit.Case
+  # doctest Organizer
+
+  defmodule SimpleExample do
+    use Interactor
+    def handle_call(%{foo: :bar}), do: {:ok, %{bar: :foo}}
+    def cleanup(%{bar: :foo}), do: {:ok, %{foo: :bar}}
+  end
+
+  defmodule SuccessExample do
+    use Interactor
+    def handle_call(%{bar: :foo}), do: {:ok, true}
+  end
+
+  defmodule FailureExample do
+    use Interactor
+    def handle_call(%{bar: :foo}) do
+      {:error, "oh no"}
+    end
+  end
+
+  defmodule ExceptionExample do
+    use Interactor
+    def handle_call(%{bar: :foo}) do
+      raise "A HUGE EXCEPTION"
+    end
+  end
+
+  defmodule MyOrganizer do
+    use Interactor.Organizer
+
+    organize [SimpleExample, SuccessExample]
+  end
+
+  defmodule CleanupOrganizer do
+    use Interactor.Organizer
+
+    organize [SimpleExample, FailureExample]
+  end
+
+  defmodule ExceptionOrganizer do
+    use Interactor.Organizer
+
+    organize [SimpleExample, ExceptionExample]
+  end
+
+  test "it works just fine" do
+    assert {:ok, true} == Interactor.call(MyOrganizer, %{foo: :bar})
+  end
+
+  test "clean up after" do
+    assert {:error, "oh no", %{bar: :foo}} == Interactor.call(CleanupOrganizer, %{foo: :bar})
+  end
+
+  test "it cleans up even if it catches an exception" do
+    assert {:error, %RuntimeError{message: "A HUGE EXCEPTION"}, %{bar: :foo}} == Interactor.call(ExceptionOrganizer, %{foo: :bar})
+  end
+end

--- a/test/organizer_test.exs
+++ b/test/organizer_test.exs
@@ -20,6 +20,12 @@ defmodule OrganizerTest do
     end
   end
 
+  defmodule SimpleExample2 do
+    use Interactor
+    def handle_call(_args), do: {:ok, %{bar: :foo, baz: :quux}}
+    def cleanup(%{bar: :foo, baz: :quux}), do: {:ok, %{bar: :foo}}
+  end
+
   defmodule ExceptionExample do
     use Interactor
     def handle_call(%{bar: :foo}) do
@@ -42,7 +48,7 @@ defmodule OrganizerTest do
   defmodule ExceptionOrganizer do
     use Interactor.Organizer
 
-    organize [SimpleExample, ExceptionExample]
+    organize [SimpleExample, SimpleExample2, ExceptionExample]
   end
 
   test "it works just fine" do
@@ -50,10 +56,10 @@ defmodule OrganizerTest do
   end
 
   test "clean up after" do
-    assert {:error, "oh no", %{bar: :foo}} == Interactor.call(CleanupOrganizer, %{foo: :bar})
+    assert {:error, "oh no", %{foo: :bar}} == Interactor.call(CleanupOrganizer, %{foo: :bar})
   end
 
   test "it cleans up even if it catches an exception" do
-    assert {:error, %RuntimeError{message: "A HUGE EXCEPTION"}, %{bar: :foo}} == Interactor.call(ExceptionOrganizer, %{foo: :bar})
+    assert {:error, %RuntimeError{message: "A HUGE EXCEPTION"}, %{foo: :bar}} == Interactor.call(ExceptionOrganizer, %{foo: :bar})
   end
 end


### PR DESCRIPTION
So I've been thinking about interactors lately, and how they can operate together. Organizers have been on my wish list for a while, and I had direct use for an organizer, so I implemented it 😄 

This is still in a bit of a transition state, but we're dogfooding it so learning about its edge cases quickly.

Even though it's not fully baked, I thought I'd put it up here to get some feedback on it. Feel free to examine at your leisure.

Some things I want to address before I feel this is ready for primetime:

- [ ] I don't really like specs around the Organizer. Error handling feels loose and unpredictable.
- [ ] README.md needs to talk about Organizers
- [ ] The `Interactor.Organizer` module needs `@moduledoc`, `@doc`s, and doctests
- [ ] This requires that all organized interactors return `{:ok, context}`, which is a dealbreaker.
    It works for us because we're lining up HTTPoison requests, but it won't work for, say, Ecto.
- [ ] It catches all exceptions and tries to rollback if any are caught. That *seems* fine, but it also doesn't do a good job of reporting the exception.
- [ ] It also seems to clobber the properties of the exception if it happens far enough down the chain. This I want to figure out and test. I think it has to due with the way `execute_interactors` tries to handle varying tuple sizes in its error handling.
- [ ] Actually test this with Ecto.
- [ ] I'd also like to put together a better story for rolling up the context.